### PR TITLE
Remove partner approval & add behavioral questions requirement

### DIFF
--- a/01/mock-interview-1-submission.md
+++ b/01/mock-interview-1-submission.md
@@ -22,27 +22,6 @@ Please enter a link to the repository you used to complete your interview. This 
 
 <!-- Question 2 -->
 ### !challenge
-* type: short-answer
-* id: 2ed2b435-15b6-46cf-b3c2-e9762eea53b9
-* title: Mock Interview Partner
-* topics: interview
-##### !question
-
-What is the first and last name of the Adie you partnered with for your mock interview? 
-
-Please note that interviewing with someone outside of Ada must be approved by a CS Fun instructor.
-
-##### !end-question
-
-##### !answer
-
-/.*/
-
-##### !end-answer
-### !end-challenge
-
-<!-- Question 3 -->
-### !challenge
 * type: paragraph
 * id: aa4f1f31-26f4-42cb-8200-23f29e5bfc74
 * title: Learnings from your Partner
@@ -54,7 +33,7 @@ What is one thing you learned from watching your partner interview?
 ##### !end-question
 ### !end-challenge
 
-<!-- Question 4 -->
+<!-- Question 3 -->
 ### !challenge
 * type: paragraph
 * id: 6c6f5805-8d92-4af5-b4af-938be00c30a0
@@ -69,7 +48,7 @@ What is one area of strength your partner demonstrated during their interview? I
 ##### !end-question
 ### !end-challenge
 
-<!-- Question 5 -->
+<!-- Question 4 -->
 ### !challenge
 * type: paragraph
 * id: e9547d67-ad73-4f4d-b519-86df1b7f6f1b

--- a/02/mock-interview-2-submission.md
+++ b/02/mock-interview-2-submission.md
@@ -22,27 +22,6 @@ Please enter a link to the repository you used to complete your interview. This 
 
 <!-- Question 2 -->
 ### !challenge
-* type: short-answer
-* id: 22ae2fa4-ff00-4561-92a3-c3c3f3f208e0
-* title: Mock Interview Partner
-* topics: interview
-##### !question
-
-What is the first and last name of the Adie you partnered with for your mock interview? 
-
-Please note that interviewing with someone outside of Ada must be approved by a CS Fun instructor.
-
-##### !end-question
-
-##### !answer
-
-/.*/
-
-##### !end-answer
-### !end-challenge
-
-<!-- Question 3 -->
-### !challenge
 * type: paragraph
 * id: e2429702-7dbd-4f57-9e11-b8039c35b1b6
 * title: Learnings from your Partner
@@ -54,7 +33,7 @@ What is one thing you learned from watching your partner interview?
 ##### !end-question
 ### !end-challenge
 
-<!-- Question 4 -->
+<!-- Question 3 -->
 ### !challenge
 * type: paragraph
 * id: dc15fd8e-859e-47ed-af7c-49f346d1d959
@@ -69,7 +48,7 @@ What is one area of strength your partner demonstrated during their interview? I
 ##### !end-question
 ### !end-challenge
 
-<!-- Question 5 -->
+<!-- Question 4 -->
 ### !challenge
 * type: paragraph
 * id: 97199321-a390-42ae-97f0-6ef10363edde

--- a/03/mock-interview-3-submission.md
+++ b/03/mock-interview-3-submission.md
@@ -22,27 +22,6 @@ Please enter a link to the repository you used to complete your interview. This 
 
 <!-- Question 2 -->
 ### !challenge
-* type: short-answer
-* id: bcdbeec0-b124-4ab7-8fbb-8ddd9cd4b590
-* title: Mock Interview Partner
-* topics: interview
-##### !question
-
-What is the first and last name of the Adie you partnered with for your mock interview? 
-
-Please note that interviewing with someone outside of Ada must be approved by a CS Fun instructor.
-
-##### !end-question
-
-##### !answer
-
-/.*/
-
-##### !end-answer
-### !end-challenge
-
-<!-- Question 3 -->
-### !challenge
 * type: paragraph
 * id: 9f46bb84-9ce9-4fdb-89fa-6cab70f89c46
 * title: Learnings from your Partner
@@ -54,7 +33,7 @@ What is one thing you learned from watching your partner interview?
 ##### !end-question
 ### !end-challenge
 
-<!-- Question 4 -->
+<!-- Question 3 -->
 ### !challenge
 * type: paragraph
 * id: 75abeed7-ca5e-4768-ab0b-3ef83b634be9
@@ -69,7 +48,7 @@ What is one area of strength your partner demonstrated during their interview? I
 ##### !end-question
 ### !end-challenge
 
-<!-- Question 5 -->
+<!-- Question 4 -->
 ### !challenge
 * type: paragraph
 * id: 88720606-f761-4968-b14f-70d9cf2ca7a0

--- a/04/mock-interview-4-submission.md
+++ b/04/mock-interview-4-submission.md
@@ -22,27 +22,6 @@ Please enter a link to the repository you used to complete your interview. This 
 
 <!-- Question 2 -->
 ### !challenge
-* type: short-answer
-* id: 209f8994-e21f-42e1-95ff-42437decb9d5
-* title: Mock Interview Partner
-* topics: interview
-##### !question
-
-What is the first and last name of the Adie you partnered with for your mock interview? 
-
-Please note that interviewing with someone outside of Ada must be approved by a CS Fun instructor.
-
-##### !end-question
-
-##### !answer
-
-/.*/
-
-##### !end-answer
-### !end-challenge
-
-<!-- Question 3 -->
-### !challenge
 * type: paragraph
 * id: 52b3d5dc-06f4-4e1e-a3db-1b6285e33ef2
 * title: Learnings from your Partner
@@ -54,7 +33,7 @@ What is one thing you learned from watching your partner interview?
 ##### !end-question
 ### !end-challenge
 
-<!-- Question 4 -->
+<!-- Question 3 -->
 ### !challenge
 * type: paragraph
 * id: 5ff3431d-30a1-4199-bdd4-8598159ba757
@@ -69,7 +48,7 @@ What is one area of strength your partner demonstrated during their interview? I
 ##### !end-question
 ### !end-challenge
 
-<!-- Question 5 -->
+<!-- Question 4 -->
 ### !challenge
 * type: paragraph
 * id: 0ae75bb0-a183-41fb-be5b-b01a0695c841

--- a/05/mock-interview-5-submission.md
+++ b/05/mock-interview-5-submission.md
@@ -22,27 +22,6 @@ Please enter a link to the repository you used to complete your interview. This 
 
 <!-- Question 2 -->
 ### !challenge
-* type: short-answer
-* id: 908caa88-f9d6-4a56-b344-cc6db92e597d
-* title: Mock Interview Partner
-* topics: interview
-##### !question
-
-What is the first and last name of the Adie you partnered with for your mock interview? 
-
-Please note that interviewing with someone outside of Ada must be approved by a CS Fun instructor.
-
-##### !end-question
-
-##### !answer
-
-/.*/
-
-##### !end-answer
-### !end-challenge
-
-<!-- Question 3 -->
-### !challenge
 * type: paragraph
 * id: e7e4c0a1-6002-401e-97b0-4c27a5ff49a9
 * title: Learnings from your Partner
@@ -54,7 +33,7 @@ What is one thing you learned from watching your partner interview?
 ##### !end-question
 ### !end-challenge
 
-<!-- Question 4 -->
+<!-- Question 3 -->
 ### !challenge
 * type: paragraph
 * id: 9ea26818-9b75-45a6-a00b-e26875a604ed
@@ -69,7 +48,7 @@ What is one area of strength your partner demonstrated during their interview? I
 ##### !end-question
 ### !end-challenge
 
-<!-- Question 5 -->
+<!-- Question 4 -->
 ### !challenge
 * type: paragraph
 * id: a0186fad-e202-4658-b366-ea2c19702cd1

--- a/about-mock-interviews/about-mocks.md
+++ b/about-mock-interviews/about-mocks.md
@@ -16,7 +16,7 @@ As part of Unit 4, you are required to complete five peer-to-peer mock interview
 ## Mock Interview Questions
 
 - [**Mock Interview Technical Question Repository**](https://docs.google.com/document/d/1SmKIpGL_z_IXhgLiaGAf3kPc_bApgH1LtIGcXVoKUHE/edit?usp=sharing)
-- [**Mock Interview Behavioral Question Repository**](BLOCKED - RESOURCE REQUIRED)
+- [**Mock Interview Behavioral Question Repository**](https://docs.google.com/document/d/1XhTN21xAsAv0bUFQFB_EFWB9qPkqZ93iaUl8hIyv6Co/edit?usp=sharing)
 
 For your five required mock interviews, we ask that you use Ada provided questions accessible via the links above. This is to ensure questions are of an appropriate scope and topic. We encourage you to explore non-Ada interview questions in your own time!
 
@@ -35,7 +35,7 @@ When you enter the mock interview, you may choose one or more technical topics f
 ## Mock Interview Structure
 At the start of a mock interview, each participant should communicate which of the topics they are comfortable interviewing in to their partner. 
 
-If this is an interview with behavioral questions, each person should start by selecting 2-3 interview question for their partner from the [Mock Interview Behavioral Question Repository](BLOCKED - RESOURCE REQUIRED).
+If this is an interview with behavioral questions, each person should start by selecting 2-3 interview question for their partner from the [Mock Interview Behavioral Question Repository](https://docs.google.com/document/d/1XhTN21xAsAv0bUFQFB_EFWB9qPkqZ93iaUl8hIyv6Co/edit?usp=sharing).
 
 Each person should then choose an interview question for their partner by selecting a question from the [Mock Interview Question Repository](https://docs.google.com/document/d/1SmKIpGL_z_IXhgLiaGAf3kPc_bApgH1LtIGcXVoKUHE/edit?usp=sharing) that is listed under their partner's chosen category(s). If someone receives a question that they have already observed or interviewed with, they should ask their partner to select a different question from their chosen categories. 
 

--- a/about-mock-interviews/about-mocks.md
+++ b/about-mock-interviews/about-mocks.md
@@ -11,18 +11,19 @@ Please watch the above video before your first mock interview so that you know w
 
 ### !end-callout
 
-As part of Unit 4, you are required to complete five peer-to-peer mock interviews on topics covered in both the Classroom CS Fundamentals and Unit 4. Mock interviews should be conducted in 90 minute sessions with a partner.
+As part of Unit 4, you are required to complete five peer-to-peer mock interviews, two of which must include behavioral interview questions. The technical material will be on topics covered in both the Classroom CS Fundamentals and Unit 4. Mock interviews should be conducted in 90 minute sessions with a partner.
 
 ## Mock Interview Questions
 
-[**Mock Interview Question Repository**](https://docs.google.com/document/d/1SmKIpGL_z_IXhgLiaGAf3kPc_bApgH1LtIGcXVoKUHE/edit?usp=sharing)
+- [**Mock Interview Technical Question Repository**](https://docs.google.com/document/d/1SmKIpGL_z_IXhgLiaGAf3kPc_bApgH1LtIGcXVoKUHE/edit?usp=sharing)
+- [**Mock Interview Behavioral Question Repository**](BLOCKED - RESOURCE REQUIRED)
 
-For your five required mock interviews, we ask that you use Ada provided questions accessible via the link above. This is to ensure questions are of an appropriate scope and topic. We encourage you to explore non-Ada interview questions in your own time!
+For your five required mock interviews, we ask that you use Ada provided questions accessible via the links above. This is to ensure questions are of an appropriate scope and topic. We encourage you to explore non-Ada interview questions in your own time!
 
 **DO NOT VIEW THE PROBLEMS BEFOREHAND**
 In order to simulate a real interview experience, please do not preview the questions beforehand. 
 
-When you enter the mock interview, you may choose one or more topics for your interviewer to select your question from. The topics are:
+When you enter the mock interview, you may choose one or more technical topics for your interviewer to select your question from. The topics are:
 - Classroom Phase (Variables & Memory, Big O, Lists, Hash Tables, Recursion)
 - Dynamic Programming
 - Linked Lists
@@ -33,6 +34,8 @@ When you enter the mock interview, you may choose one or more topics for your in
 
 ## Mock Interview Structure
 At the start of a mock interview, each participant should communicate which of the topics they are comfortable interviewing in to their partner. 
+
+If this is an interview with behavioral questions, each person should start by selecting 2-3 interview question for their partner from the [Mock Interview Behavioral Question Repository](BLOCKED - RESOURCE REQUIRED).
 
 Each person should then choose an interview question for their partner by selecting a question from the [Mock Interview Question Repository](https://docs.google.com/document/d/1SmKIpGL_z_IXhgLiaGAf3kPc_bApgH1LtIGcXVoKUHE/edit?usp=sharing) that is listed under their partner's chosen category(s). If someone receives a question that they have already observed or interviewed with, they should ask their partner to select a different question from their chosen categories. 
 
@@ -81,9 +84,9 @@ The variety of partners recommendation is to encourage you to experience differe
 ## Scheduling Mock Interviews
 Ada provides 100 minute instructor facilitated mock interview sessions every other week. During the first ten minutes, instructors will split you into random pairs based on the topics you would like to interview in that day.  **You must arrive within the first five minutes** of the scheduled session in order to be guaranteed a partner. 
 
-Check the [Unit 4 Calendar](https://calendar.google.com/calendar/embed?src=c_d44b988d1234b8420687c70615bd50ffa62ce2e2baa05abafa03c0998d2ebd64%40group.calendar.google.com&ctz=America%2FLos_Angeles) to view available Ada facilitated mock interview session. Mock interview pairing will take place at the end of Review Sessions for all 5 topics.
+To view available Ada facilitated mock interview sessions, check the calendar for your cohort by clicking your cohort's link on the [Ada Core Hub site](https://sites.google.com/adadevelopersacademy.org/adacorehub/home). Mock interview pairing will take place at the end of Review Sessions for all 5 topics.
 
-If you would like to schedule your own sessions, you are free to coordinate with your fellow Adies and organize alternative sessions. Consider finding partners by posting a request in the `#find-interview-partners` channel on Slack.
+If you would like to schedule your own mock interview sessions, you are free to coordinate with your fellow Adies or other folks you trust to organize alternative sessions. Consider finding partners by posting a request in the `#find-interview-partners` channel on Slack.
 
 ## Reminders
 - It's **100% okay** not to finish the problem in the allotted time. 


### PR DESCRIPTION
Asana Tickets
- [Remove pre-approval requirement for Mock Interview Retrospectives](https://app.asana.com/0/1205655776549324/1209323104385168)
- [Update About Mock Interviews for C22](https://app.asana.com/0/1205655776549324/1209323104385166)

Changes
- Remove language about pre-approving mock interview partners by removing partner name submission for each mock interview. 
- Redirect students to Core Hub cohort calendar for mock interview schedule. 
- Add language about 2 mock interviews requiring behavioral component. 
- Add links to behavioral interview question list